### PR TITLE
change role permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+dist/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ make deploy
     - This step deploys a Role that allows users read access to AWS Organizations to pull account names and metadata tags. 
     
 ```shell script
- make add-org-read-role  MASTER_ACCOUNT_ID=<MASTER_ACCOUNT_ID> CUSTOM_AUD=<URL OUTPUT FROM DEPLOY STEP>
+
+ make add-org-read-role  MASTER_ACCOUNT_ID=`terraform output -state=terraform/aws/terraform.tfstate master_account` CUSTOM_AUD=`terraform output -state=terraform/aws/terraform.tfstate base_url` LAMBDA_ARN=`terraform output -state=terraform/aws/terraform.tfstate lambda_role_arn`
 ```
 
 6. [Optional] Assign org read role ro users within the IdP (e.g. KeyCloak) to allow access account metadata.

--- a/makefile
+++ b/makefile
@@ -21,6 +21,7 @@ endif
 deploy: $(lamba_samlpost.zip) check_aws_login
 	@echo "Deploying app to AWS."
 	@cd terraform/aws && terraform apply
+	
 
 add-org-read-role: check_aws_login
 ifeq ($(MASTER_ACCOUNT_ID),)
@@ -29,8 +30,11 @@ endif
 ifeq ($(CUSTOM_AUD),)
 	$(error CUSTOM_AUD is not set)
 endif
-	@aws cloudformation deploy --template-file master_account_read_role.yaml --stack-name saml-read-role --parameter-overrides IDP=arn:aws:iam::$(MASTER_ACCOUNT_ID):saml-provider/BCGovKeyCloak CustomAud=$(CUSTOM_AUD) --capabilities CAPABILITY_NAMED_IAM
+ifeq ($(LAMBDA_ARN),)
+	$(error LAMBDA_ARN is not set)
+endif
 
+	@aws cloudformation deploy --template-file master_account_read_role.yaml --stack-name saml-read-role --parameter-overrides IDP=arn:aws:iam::$(MASTER_ACCOUNT_ID):saml-provider/BCGovKeyCloak CustomAud=$(CUSTOM_AUD) LambdaArn=$(LAMBDA_ARN) --capabilities CAPABILITY_NAMED_IAM --tags Project="SAML Login Provider" Environment="Development"
 clean:
 	-@rm -rf dist
 

--- a/master_account_read_role.yaml
+++ b/master_account_read_role.yaml
@@ -5,6 +5,8 @@ Parameters:
     Type: String
   CustomAud:
     Type: String
+  LambdaArn:
+    Type: String
 
 Resources:
   SAMLOrganizationsReadRole:
@@ -26,6 +28,27 @@ Resources:
                 SAML:aud: 
                   - https://signin.aws.amazon.com/saml
                   - !Ref CustomAud
+      Policies:
+        - PolicyName: deny_all
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Deny
+                Action: "*"
+                Resource: "*"
+  SAMLLambdaOrganizationsReadRole:
+    Type: AWS::IAM::Role
+    Properties:      
+      RoleName: "BCGOV_Lambda_Organizations_Read_Role" #The value is referenced in the terraform
+      MaxSessionDuration: 3600
+      Path: /      
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+            - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !Ref LambdaArn
       Policies:
         - PolicyName: saml_user_account_readpolicy
           PolicyDocument:

--- a/terraform/aws/lambda.tf
+++ b/terraform/aws/lambda.tf
@@ -12,6 +12,7 @@ resource "aws_lambda_function" "samlpost" {
 
    environment {
     variables = {
+      lambdaReadRole = local.lambda_read_role_arn
       samlReadRole = "arn:aws:iam::${var.master_account_id}:saml-provider/${var.keycloak_saml_name},arn:aws:iam::${var.master_account_id}:role/${local.saml_read_role_name}"
     }
   }
@@ -40,6 +41,38 @@ resource "aws_iam_role" "lambda_exec" {
 }
 
 
+resource "aws_iam_role_policy" "lambda_exec_org_policy" {
+  name = "serverless_saml_lambda_read_orgs"
+  role = aws_iam_role.lambda_exec.id
+
+  policy = <<-EOF
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "logs:CreateLogGroup",
+                  "logs:CreateLogStream",
+                  "logs:PutLogEvents",
+                  "logs:DescribeLogStreams"
+              ],
+              "Resource": [
+                  "arn:aws:logs:*:*:*"
+              ]
+          },
+          {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRole",
+              "Resource": "arn:aws:iam::${var.master_account_id}:role/BCGOV_Lambda_Organizations_Read_Role"
+          }
+      ]
+  }
+EOF
+}
+
+
+
 
 
 data "aws_iam_policy" "AWSLambdaBasicExecutionRole" {
@@ -60,4 +93,9 @@ resource "aws_lambda_permission" "apigw" {
   # The "/*/*" portion grants access from any method on any resource
   # within the API Gateway REST API.
   source_arn = "${aws_api_gateway_rest_api.samlpost.execution_arn}/*/*"
+}
+
+
+output "lambda_role_arn" {
+  value =  aws_iam_role.lambda_exec.arn
 }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -9,6 +9,10 @@ locals {
     Project = "SAML Login Provider"
     Environment = "Development"
   }
-   
+  lambda_read_role_arn = "arn:aws:iam::${var.master_account_id}:role/BCGOV_Lambda_Organizations_Read_Role" # This is referenced in the master_account_read_role.yaml
   saml_read_role_name = "BCGOV_SAML_Organizations_Read_Role" # This is referenced in the master_account_read_role.yaml
+}
+
+output "master_account" {
+  value = var.master_account_id
 }


### PR DESCRIPTION
Changed the role permission implementation for getting account name and account tags:

- Initial implementation assigned read permissions to the role that users could assume. 
  - could be possible for a user to learn the role name and execute a describe-account on any organization account.

- this implementation does the following
  - the role for users to assume still exists, but the read permissions replaced with a Deny All. It is no longer possible for a user to execute the describe-account like before.
  - the lambda function has permissions to assume a new role that contains the specific read org account permissions
  - the lambda function still assumes the end user role (even though the permissions are Deny All). This is done to ensure the role exists in the user's SAML response and that the SAML response is valid.

Steps to Update:
1. `make package-lambda `
2. `make deploy`

3. [With Master Account Credentials]  
``
make add-org-read-role  MASTER_ACCOUNT_ID=`terraform output -state=terraform/aws/terraform.tfstate master_account` CUSTOM_AUD=`terraform output -state=terraform/aws/terraform.tfstate base_url` LAMBDA_ARN=`terraform output -state=terraform/aws/terraform.tfstate lambda_role_arn`
``