### PR TITLE
change default region for console sign in

### DIFF
--- a/lambda/samlpost/index.js
+++ b/lambda/samlpost/index.js
@@ -182,7 +182,7 @@ exports.handler = function (event, context, callback) {
 
                             requestParams = "?Action=login";
                             requestParams += `&Issuer=${issuer}`;
-                            requestParams += `&Destination=https://console.aws.amazon.com/`;
+                            requestParams += `&Destination=https://console.aws.amazon.com/?region=ca-central-1`;
                             requestParams += `&SigninToken=${signInToken}`
 
                             requestUrl = "https://signin.aws.amazon.com/federation" + requestParams;


### PR DESCRIPTION
change the default region when signing into the AWS console to the Canadian region.