### PR TITLE
update nodejs lambda runtime  12 -> 14

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "samlpost" {
   //	source_code_hash = filebase64sha256(data.archive_file.lambda_zip.output_path)
 
   handler = "index.handler"
-  runtime = "nodejs12.x"
+  runtime = "nodejs14.x"
   timeout = 10
 
   role = aws_iam_role.lambda_exec.arn


### PR DESCRIPTION
## Describing the issue
The version 12 of NodeJS is being deprecated as an AWS Lambda runtime.
To remediate the issue we are upgrading to the version 14.
No breaking change appeared in the changelog of NodeJS

## Test
 - [x] Has been deployed on lz0
 - [x] Has been deployed on lz1
 - [x] Has been deployed on lz2