### PR TITLE
add health check link description

### DIFF
--- a/lambda/samlpost/index.html
+++ b/lambda/samlpost/index.html
@@ -552,7 +552,7 @@
 
       <div id="external-dashboard" class="tabcontent">
         <ul>
-          <li><a href="https://status.aws.amazon.com" target="_blank">AWS Status Page</a></li>
+          <li><a href="https://status.aws.amazon.com" target="_blank">AWS Status Page (please connect to an aws account first)</a></li>
           <li><a href="https://status.hashicorp.com" target="_blank">Terraform Status Page</a></li>
           <li><a href="https://www.githubstatus.com" target="_blank">GitHub Status Page</a></li>
         </ul>


### PR DESCRIPTION
# Context
We want to warn the user to log in before clicking on the AWS health check link
Indeed else they reach the global page of AWS Health check and not the wanted account

## Changes
- [x] Add description next to the health check link

## Test
- [x] Deploy on lz0  
![image](https://user-images.githubusercontent.com/74857643/200445120-f0e1154f-84e2-4e96-8a51-124359e6604b.png)
