### PR TITLE
Keycloack migration

### DIFF
--- a/lambda/samlpost/index.html
+++ b/lambda/samlpost/index.html
@@ -406,7 +406,7 @@
     function parseSAMLResponse(samlResponse) {
       //let capturingRegex = new RegExp(">(?<provider>arn:aws:iam::\\d+:saml-provider/\\S+),(?<role>arn:aws::iam::(?<accountid>\\d+):role/(?<rolename>\\w+))<");
       let capturingRegex = new RegExp(
-        ">(arn:aws:iam::\\d+:saml-provider/\\S+),(arn:aws:iam::(\\d+):role/(\\w+))<",
+        ">(arn:aws:iam::\\d+:saml-provider/[a-zA-Z0-9-_@=+.]+),(arn:aws:iam::(\\d+):role/([a-zA-Z0-9-_@=+.]+))<",
         "gi"
       );
       ///>(arn:aws:iam::\d+:saml-provider\/\S+),(arn:aws:iam::(\d+):role\/(\w+))</gi

--- a/lambda/samlpost/index.html
+++ b/lambda/samlpost/index.html
@@ -194,9 +194,12 @@
         decodedSAMLResponse
       )}/protocol/saml/clients/amazon-aws`;
 
-      const logoutURL = `${getSAMLIssuer(
-        decodedSAMLResponse
-      )}/protocol/openid-connect/logout`;
+      const samlIssuerURL = getSAMLIssuer(decodedSAMLResponse)
+      const CaptureURLRegex = new RegExp(
+        "((http[s]):\\/?\\/?[^:\\/\\s]+)(\\/\\w+)*\\/[\\w\\-\\.]+[^#?\\s]+.*?(#[\\w\\-]+)?$"
+      )
+      let ParsedURL = samlIssuerURL.match(CaptureURLRegex)
+      const logoutURL = `${ParsedURL[1]}/auth/realms/standard/protocol/openid-connect/logout`
 
       $("#logout").html(
         `<a href="${logoutURL}?redirect_uri=${encodeURIComponent(

--- a/lambda/samlpost/index.js
+++ b/lambda/samlpost/index.js
@@ -221,7 +221,7 @@ exports.handler = function (event, context, callback) {
 
 function parseSAMLResponse(samlResponse) {
     //let capturingRegex = new RegExp(">(?<provider>arn:aws:iam::\\d+:saml-provider/\\S+),(?<role>arn:aws::iam::(?<accountid>\\d+):role/(?<rolename>\\w+))<");
-    let capturingRegex = new RegExp(">(arn:aws:iam::\\d+:saml-provider/[a-zA-Z-_@=+.]+),(arn:aws:iam::(\\d+):role/([a-zA-Z-_@=+.]+))<", "gi");
+    let capturingRegex = new RegExp(">(arn:aws:iam::\\d+:saml-provider/[a-zA-Z0-9-_@=+.]+),(arn:aws:iam::(\\d+):role/([a-zA-Z0-9-_@=+.]+))<", "gi");
     ///>(arn:aws:iam::\d+:saml-provider\/\S+),(arn:aws:iam::(\d+):role\/(\w+))</gi
     let matches = samlResponse.matchAll(capturingRegex);
 

--- a/lambda/samlpost/index.js
+++ b/lambda/samlpost/index.js
@@ -221,7 +221,7 @@ exports.handler = function (event, context, callback) {
 
 function parseSAMLResponse(samlResponse) {
     //let capturingRegex = new RegExp(">(?<provider>arn:aws:iam::\\d+:saml-provider/\\S+),(?<role>arn:aws::iam::(?<accountid>\\d+):role/(?<rolename>\\w+))<");
-    let capturingRegex = new RegExp(">(arn:aws:iam::\\d+:saml-provider/\\S+),(arn:aws:iam::(\\d+):role/(\\w+))<", "gi");
+    let capturingRegex = new RegExp(">(arn:aws:iam::\\d+:saml-provider/[a-zA-Z-_@=+.]+),(arn:aws:iam::(\\d+):role/([a-zA-Z-_@=+.]+))<", "gi");
     ///>(arn:aws:iam::\d+:saml-provider\/\S+),(arn:aws:iam::(\d+):role\/(\w+))</gi
     let matches = samlResponse.matchAll(capturingRegex);
 


### PR DESCRIPTION
# Keycloack migration from emerald to gold
The Keycloack migration created bug in the login app du to a few changes in parsing and naming policy
This PR fixed the issue and make the aws-login app work with the new keycloack

## Change
 - [x] Change the regex to catch the new naming conventions
 - [ ] Change the creation of the logout URL du to modification on the gold cluster IDP Config

## Test 
- [x] Terraform plan
- [x] Terraform apply
- [x] Connection to overlay and workspace repos
- [x] Logout url redirection