### PR TITLE
fix: temp lz2 deployment

### DIFF
--- a/lambda/samlpost/index.html
+++ b/lambda/samlpost/index.html
@@ -194,12 +194,9 @@
         decodedSAMLResponse
       )}/protocol/saml/clients/amazon-aws`;
 
-      const samlIssuerURL = getSAMLIssuer(decodedSAMLResponse)
-      const CaptureURLRegex = new RegExp(
-        "((http[s]):\\/?\\/?[^:\\/\\s]+)(\\/\\w+)*\\/[\\w\\-\\.]+[^#?\\s]+.*?(#[\\w\\-]+)?$"
-      )
-      let ParsedURL = samlIssuerURL.match(CaptureURLRegex)
-      const logoutURL = `${ParsedURL[1]}/auth/realms/standard/protocol/openid-connect/logout`
+      const logoutURL = `${getSAMLIssuer(
+        decodedSAMLResponse
+      )}/protocol/openid-connect/logout`;
 
       $("#logout").html(
         `<a href="${logoutURL}?redirect_uri=${encodeURIComponent(


### PR DESCRIPTION
# Description 

We needed to deploy the new version of the AWS-login App on live but this environment has not been migrated to the gold cluster.
This is a issue because of the way we catch the logout URL in the new keycloack realm.
This PR purpose is only to fix this issue.

## Changes
- [x] Catch the Logout URL for silver keycloack realm.

## Tests
- [x] Deployed on Live
- [x] Test connextion through login-app
- [x] Test log out