### PR TITLE
User group migration script from silver to gold 

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -21,11 +21,15 @@ resource "aws_lambda_function" "samlpost" {
 
   environment {
     variables = {
-      samlReadRole                    = "arn:aws:iam::${local.master_account_id}:saml-provider/${var.keycloak_saml_name},arn:aws:iam::${local.master_account_id}:role/${local.saml_read_role_name}",
-      kc_base_url                     = var.kc_base_url,
-      kc_realm                        = var.kc_realm,
-      kc_terraform_auth_client_id     = var.kc_terraform_auth_client_id,
-      kc_terraform_auth_client_secret = var.kc_terraform_auth_client_secret
+      samlReadRole                           = "arn:aws:iam::${local.master_account_id}:saml-provider/${var.keycloak_saml_name},arn:aws:iam::${local.master_account_id}:role/${local.saml_read_role_name}",
+      kc_base_url                            = var.kc_base_url,
+      kc_realm                               = var.kc_realm,
+      kc_terraform_auth_client_id            = var.kc_terraform_auth_client_id,
+      kc_terraform_auth_client_secret        = var.kc_terraform_auth_client_secret
+      silver_kc_realm                        = var.silver_kc_realm
+      silver_kc_base_url                     = var.silver_kc_base_url
+      silver_kc_terraform_auth_client_id     = var.silver_kc_terraform_auth_client_id
+      silver_kc_terraform_auth_client_secret = var.silver_kc_terraform_auth_client_secret
     }
   }
 

--- a/lambda/samlpost/index.js
+++ b/lambda/samlpost/index.js
@@ -7,7 +7,7 @@ let https = require('https');
 var qs = require('querystring');
 
 exports.handler = function (event, context, callback) {
-  if (event.path == "/redirect" && event.httpMethod == "GET") {
+  if ((event.path == "/redirect" && event.httpMethod == "GET") || (event.path == "/" && event.httpMethod == "GET")) {
     const kc_base_url = process.env.kc_base_url;
     const kc_realm = process.env.kc_realm;
     const response = {

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,30 @@ variable "kc_terraform_auth_client_secret" {
   default     = ""
 }
 
+variable "silver_kc_realm" {
+  description = "Silver keycloack cluster realm name"
+  type = string
+  default = ""
+}
+
+variable "silver_kc_base_url" {
+  description = "Silver keycloack cluster base url"
+  type = string
+  default = ""
+}
+
+variable "silver_kc_terraform_auth_client_id" {
+  description = "Silver keycloack cluster client name"
+  type = string
+  default = ""
+}
+
+variable "silver_kc_terraform_auth_client_secret" {
+  description = "Silver keycloack cluster client password"
+  type = string
+  default = ""
+}
+
 variable "domain_name" {
   description = "Domain name of the login app"
   type        = string


### PR DESCRIPTION
# Group migration script from silver to gold
In the context of migrating from the keycloack silver realm to the gold cluster we need to migrate users on our live environment.
For that we are using a script in the login-app that will, when a user get connected, get the groups of the said user in the silver realm and look in the gold cluster to assign the users to the previous groups.

## Changes:
 - [x] Add migration script
 - [x] Add redirection on `/` and method `get`
 - [x] Disable silver user to do the migration only once per users
 - [x] A few variable to access both the gold and the realm keycloack cluster
 
 ## Tests
 - [x] Terrafom apply
 - [x] Connecting a user for the first time and get migrated
 - [x] Connection already migrated users and not trigger migration mechanisms