### PR TITLE
Include AWS_REGION in credentials

### DIFF
--- a/lambda/samlpost/index.html
+++ b/lambda/samlpost/index.html
@@ -390,7 +390,7 @@
           '"\nexport AWS_SESSION_TOKEN="' +
           sessionToken +
           '"\nexport AWS_DEFAULT_REGION=ca-central-1' +
-          '"\nexport AWS_REGION=ca-central-1\n';
+          '\nexport AWS_REGION=ca-central-1\n';
 
         $("#dialog pre").first().html(text);
 

--- a/lambda/samlpost/index.html
+++ b/lambda/samlpost/index.html
@@ -389,7 +389,8 @@
           secretKey +
           '"\nexport AWS_SESSION_TOKEN="' +
           sessionToken +
-          '"\nexport AWS_DEFAULT_REGION=ca-central-1\n';
+          '"\nexport AWS_DEFAULT_REGION=ca-central-1' +
+          '"\nexport AWS_REGION=ca-central-1\n';
 
         $("#dialog pre").first().html(text);
 


### PR DESCRIPTION
Populating the AWS_REGION variable is a necessary step when loading the configuration credentials in the terminal. The variable is the same as AWS_DEFAULT_REGION. Adding this line of code in will save devs from having to set the additional variable when importing credentials.