### PR TITLE
Adds some margin to the bottom of the footer so that the footer does…

### DIFF
--- a/lambda/samlpost/index.html
+++ b/lambda/samlpost/index.html
@@ -124,6 +124,7 @@
       padding: 6px 12px;
       border: 1px solid #ccc;
       border-top: none;
+      margin-bottom: 50px;
     }
 
     a:hover {


### PR DESCRIPTION
…n't obscure the last element in a list.

Before:

![image](https://github.com/BCDevOps/aws-login/assets/51633/564538a5-f51e-45b1-a388-f4d4a965e745)


After:

![image](https://github.com/BCDevOps/aws-login/assets/51633/2d8369ce-3c48-4779-8307-690a6894ff9d)

